### PR TITLE
Fixed the error of printing Fizz instead of FizzBuzz for the case of number being a multiple of both 3 and 5

### DIFF
--- a/JavaScript.js
+++ b/JavaScript.js
@@ -1,3 +1,2 @@
-for (var i = 1; i <= 100; i++)
-    i % 3 == 0 ? console.log("Fizz") : i % 5 == 0 ? console.log("Buzz") : i % 3 == 0 && i % 5 == 0 ? console.log("FizzBuzz") : console.log(i);
-
+for (let i = 1; i <= 100; i++)
+(i % 3 === 0 && i % 5 === 0) ? console.log("FizzBuzz") : (i % 3 === 0 ? console.log("Fizz") : (i % 5 === 0 ? console.log("Buzz") : console.log(i)));

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To learn more and see clean versions, see: https://wiki.c2.com/?FizzBuzzTest
 - [C++](C++.cpp), 13 lines
 - [Go](Go.go), 16 lines
 - [Java](Java.java), 15 lines
-- [JavaScript](JavaScript.js), 3 lines
+- [JavaScript](JavaScript.js), 2 lines
 - [JavaScript](js.js), 6 lines but 22 words
 - [Python2](Python2.py), 10 lines
 - [Python3](Python3.py), 2 lines


### PR DESCRIPTION
Made the following changes:
* Fixed the error of printing Fizz instead of FizzBuzz for the case of number being a multiple of both 3 and 5
* Updated the code to follow ES6 standards.