### PR TITLE
Fix python3 byte count in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To learn more and see clean versions, see: https://wiki.c2.com/?FizzBuzzTest
 - [JavaScript](JavaScript.js), 107 bytes
 - [PHP](PHP.php), 244 bytes
 - [Python2](Python2.py), 140 bytes
-- [Python3](Python3.py), 61 bytes
+- [Python3](Python3.py), 108 bytes
 - [R](R.R),110 bytes
 - [Ruby](Ruby.rb), 82 bytes
 - [Rust](Rust.rs),188 bytes


### PR DESCRIPTION
Fix [issue](https://github.com/rsha256/shortest-fizzbuzz/issues/26).