### PR TITLE
Shorter Rust example, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To learn more and see clean versions, see: https://wiki.c2.com/?FizzBuzzTest
 - [Python3](Python3.py), 61 bytes
 - [R](R.R),110 bytes
 - [Ruby](Ruby.rb), 69 bytes
-- [Rust](Rust.rs),174 bytes
+- [Rust](Rust.rs), 115 bytes
 - [Scheme](Scheme.scm), 433 bytes
 - [Swift](Swift.swift), 578 bytes
 

--- a/Rust.rs
+++ b/Rust.rs
@@ -1,3 +1,1 @@
-fn main() {
-  (1..=100).for_each(|x| println!("{}", match (x%3, x%5) {(0,0) => "FizzBuzz".into(), (0, _) => "Fizz".into(), (_,0) => "Buzz".into(), (_,_) => x.to_string()}))
-}
+fn main(){for i in 1..100{if i%3<1{print!("Fizz")}if i%5<1{print!("Buzz")}else if i%3>0{print!{"{i}"}}println!()}}


### PR DESCRIPTION
A little trickery to get the Rust example a bit smaller, now down to 115 bytes.