### PR TITLE
Added a shorter 69 bytes (nice) PHP version

### DIFF
--- a/PHP.php
+++ b/PHP.php
@@ -1,6 +1,2 @@
-foreach (range(1, 100) as $number) {
-    $isFizz = $number % 3 == 0;
-    $isBuzz = $number % 5 == 0;
-    $fizzBuzz = ($isFizz ? 'Fizz' : '') . ($isBuzz ? 'Buzz' : '');
-    echo  !empty($fizzBuzz) ? $fizzBuzz.'<br>' : (string)$number .'<br>';
-}
+<?php
+for(;@$i++<100;)echo@(['Fizz'][$i%3].['Buzz'][$i%5]?:$i),"\n";

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To learn more and see clean versions, see: https://wiki.c2.com/?FizzBuzzTest
 - [Java](Java.java), 106 bytes
 - [JavaScript](JavaScript.js), 64 bytes
 - [Perl6](Perl6.pl), 54 bytes
-- [PHP](PHP.php), 244 bytes
+- [PHP](PHP.php), 69 bytes
 - [Python2](Python2.py), 59 bytes
 - [Python3](Python3.py), 61 bytes
 - [R](R.R),110 bytes


### PR DESCRIPTION
Hi!

I just added a one-liner shorter version in PHP of 69 bytes, I made it a while back and I think it'd be nice to have it here.

The original PHP solution didn't have the opening ```<?php```, so technically it would not run, so I've also added it.

Here is the solution:
```php
<?php
for(;@$i++<100;)echo@(['Fizz'][$i%3].['Buzz'][$i%5]?:$i),"\n";
```

It uses ```@``` to avoid throwing errors in a few places as I abuse the implicit integer ```$i``` definition as 0 when adding to an undefined variable, and also same when accessing an undefined index on an array, which this way just returns ```NULL```, when concatenated it coerces to an empty string "".

Then I just evalueate the string, anything other than empty or false will give true, thus displaying, if not fizz or buzz have been concatenated, then it's empty and so it returns the number in $i.

The "\n" could be replaced by a literal LF in the file, and we'd lose a byte, but:
1. It would no longer be a one-liner
2. It would not be 69 bytes (nice)

Thanks for merging it!