### PR TITLE
C fizzbuzz in 95 bytes

### DIFF
--- a/C.c
+++ b/C.c
@@ -1,2 +1,2 @@
 #define p printf(
-main(i){for(;i%101;i++){p i%3?"":"Fizz")+p i%5?"":"Buzz")?:p"%d",i);p"\n");}}
+main(i){for(;i<101;i++){p i%3?"":"Fizz")+p i%5?"":"Buzz")?:p"%d",i);p"\n");}}

--- a/C.c
+++ b/C.c
@@ -1,2 +1,2 @@
-#include <stdio.h>
-main(i){for(;i<101;i++)printf(i%3?i%5?"%d\n":"Buzz\n":i%5?"Fizz\n":"FizzBuzz\n",i);}
+#define p printf(
+main(i){for(;i%101;i++){p i%3?"":"Fizz")+p i%5?"":"Buzz")?:p"%d",i);p"\n");}}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To learn more and see clean versions, see: https://wiki.c2.com/?FizzBuzzTest
 ** **
 
 ## Languages:
-- [C](C.c), 104 bytes
+- [C](C.c), 95 bytes
 - [C++](C++.cpp), 231 bytes
 - [Dart](Dart.dart), 124 bytes
 - [Elm](Elm.elm), 297 bytes
@@ -29,8 +29,8 @@ To learn more and see clean versions, see: https://wiki.c2.com/?FizzBuzzTest
 - [Swift](Swift.swift), 578 bytes
 
 ## Contributing:
-1. Alphabetically add your addition here to [README.md](README.md) in the format `[<language name>](<file-name>), <number-of-bytes> bytes`. GitHub tells you the number of **bytes** for any file. 
-2. Add a file to the root of the repo in the form of: `<language-name>.<file-extension>` that satisfies the rules above. 
+1. Alphabetically add your addition here to [README.md](README.md) in the format `[<language name>](<file-name>), <number-of-bytes> bytes`. GitHub tells you the number of **bytes** for any file.
+2. Add a file to the root of the repo in the form of: `<language-name>.<file-extension>` that satisfies the rules above.
 
 ## Notes:
 Try to write a detailed commit message.


### PR DESCRIPTION
A few tricks are used to reach this number.

## Header omission

Many C compilers only give warning when forgetting to `#include <stdio.h>` so it can be ommitted.

## Macro abuse

Macros are just a big search&replace. Nothing stops me from adding an unclosed `(` inside my macro, it will still compile. Hence, everywhere the letter `p` appears, it gets replaced by `printf(`. I only have to remember to close the parentheses. This makes the code quite a bit harder to read so here is the expanded version you can read as reference:

```c
main(i){for(;i<101;i++){printf( i%3?"":"Fizz")+printf( i%5?"":"Buzz")?:printf("%d",i);printf("\n");}}
```


## printf returns the number of printed characters

Since both "Fizz" and "Buzz" have 4 letters, we can sum both and use it as a ternary input. Both 4 and 8 are consided truthy/non-zero and will trigger the left half of the ternary (which is nothing) when getting printed.

Only if neither get printed will this ternary use the false branch which prints the index.